### PR TITLE
Increase dopamine max multiplier and adjust UI offsets

### DIFF
--- a/the-scrolling-dead/src/core/DopamineManager.gd
+++ b/the-scrolling-dead/src/core/DopamineManager.gd
@@ -78,7 +78,7 @@ func _apply_base_effects():
 		5.0,   # base_decay_rate
 		0.1,   # decay_interval
 		0.4,   # acceleration_rate 
-		12.0   # max_multiplier
+		200.0   # max_multiplier
 	)
 	effect_manager.add_effect(decay_modifier_effect)
 

--- a/the-scrolling-dead/src/core/screens_slider.gd
+++ b/the-scrolling-dead/src/core/screens_slider.gd
@@ -63,7 +63,7 @@ func _on_ButtonNext_pressed() -> void:
 	go_next()
 	var rand = randf_range(10,800)
 	DopamineManager.increment(rand)
-	DopamineManager.reset_effects()
+	#DopamineManager.reset_effects()
 	
 	# Emitir señal de scroll para que ScoreManager la capture
 	emit_signal("scrolled")

--- a/the-scrolling-dead/src/ui/ScoreScreen.tscn
+++ b/the-scrolling-dead/src/ui/ScoreScreen.tscn
@@ -27,9 +27,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -300.0
-offset_top = -466.0
+offset_top = -482.0
 offset_right = 300.0
-offset_bottom = 466.0
+offset_bottom = 482.0
 grow_horizontal = 2
 grow_vertical = 2
 


### PR DESCRIPTION
Raised the max_multiplier in DopamineManager from 12.0 to 200.0 to allow for higher effect scaling. Commented out DopamineManager.reset_effects() in screens_slider.gd to prevent effect reset on next button press. Adjusted ScoreScreen.tscn vertical offsets for improved UI layout.